### PR TITLE
Fix run top percentile

### DIFF
--- a/Stats/CurrentRunPbStat.cs
+++ b/Stats/CurrentRunPbStat.cs
@@ -118,25 +118,18 @@ namespace Celeste.Mod.ConsistencyTracker.Stats {
             string runStatusPercentStr, runStatusPercentSessionStr;
             string topXPercentStr, topXPercentSessionStr;
 
-            if (totalGoldenRuns == 0) {
-                runStatusPercentStr = "100%";
-                topXPercentStr = "0%";
-            } else {
-                double runStatusPercent = (double)goldenDeathsUntilRoom / totalGoldenRuns;
 
-                runStatusPercentStr = $"{StatManager.FormatPercentage(runStatusPercent)}";
-                topXPercentStr = $"{StatManager.FormatPercentage(1 - runStatusPercent)}";
-            }
+            double runStatusPercent = (double)goldenDeathsUntilRoom / (totalGoldenRuns + 1);
 
-            if (totalGoldenRunsSession == 0) {
-                runStatusPercentSessionStr = "100%";
-                topXPercentSessionStr = "0%";
-            } else {
-                double runStatusPercentSession = (double)goldenDeathsUntilRoomSession / totalGoldenRunsSession;
+            runStatusPercentStr = $"{StatManager.FormatPercentage(runStatusPercent)}";
+            topXPercentStr = $"{StatManager.FormatPercentage(1 - runStatusPercent)}";
+            
 
-                runStatusPercentSessionStr = $"{StatManager.FormatPercentage(runStatusPercentSession)}";
-                topXPercentSessionStr = $"{StatManager.FormatPercentage(1 - runStatusPercentSession)}";
-            }
+            double runStatusPercentSession = (double)goldenDeathsUntilRoomSession / (totalGoldenRunsSession + 1);
+
+            runStatusPercentSessionStr = $"{StatManager.FormatPercentage(runStatusPercentSession)}";
+            topXPercentSessionStr = $"{StatManager.FormatPercentage(1 - runStatusPercentSession)}";
+            
 
             format = format.Replace(RunCurrentPbStatusPercent, runStatusPercentStr);
             format = format.Replace(RunCurrentPbStatusPercentSession, runStatusPercentSessionStr);


### PR DESCRIPTION
There is a bug with the percentile calculation. For example, lets say I am on my 100th run, and it is currently the top run. That means that there are 99 runs worse than it, making it the 99th percentile run (top 1%). But currently this is calculated to be a 100th percentile run (top 0%). There is no such thing as being in the 100th percentile so this can't be right.